### PR TITLE
deprecate ssb:feed/ed25519 and add ssb:feed/classic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# 2.0.0
+
+Support ssb-uri-spec version 1.1, which means that we added support for `ssb:feed/classic` as first-class URIs, while `ssb:feed/ed25519` is still supported, but is deprecated. (Similarly for `ssb:message/classic` and `ssb:message/ed25519`, `ssb:blob/classic` and `ssb:blob/ed25519`.)
+
+`compose({type: 'feed', format: 'ed25519', data})` is still going to return the deprecated URI `ssb:feed/ed25519/${data}`, but `decompose(uri)` will return `{type: 'feed', format: 'classic', data}`.
+
+**Breaking change:**
+
+- `isFeedSSBURI` renamed to `isClassicFeedSSBURI`
+- `isMessageSSBURI` renamed to `isClassicMessageSSBURI`
+- `isBlobSSBURI` renamed to `isClassicBlobSSBURI`
+
+# 1.9.0
+
+Support buttwoo feed URIs with 4 parts, i.e., an extra data part:
+
+```
+ssb:feed/buttwoo-v1/<FEEDID>/<PARENTMSGID>
+```

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,9 @@ npm install ssb-uri2
 const ssbUri = require('ssb-uri2');
 
 const exampleURI =
-  'ssb:message/sha256/g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=';
+  'ssb:message/classic/g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=';
 
-ssbUri.isMessageSSBURI(exampleURI);
+ssbUri.isClassicMessageSSBURI(exampleURI);
 // true
 
 ssbUri.toMessageSigil(exampleURI);
@@ -29,19 +29,19 @@ ssbUri.toMessageSigil(exampleURI);
 
 ### `isSSBURI(uri: string | uri): boolean`
 
-### `isFeedSSBURI(uri: string | null): boolean`
+### `isClassicFeedSSBURI(uri: string | null): boolean`
 
 ### `isBendyButtV1FeedSSBURI(uri: string | null): boolean`
 
 ### `isGabbyGroveV1FeedSSBURI(uri: string | null): boolean`
 
-### `isMessageSSBURI(uri: string | null): boolean`
+### `isClassicMessageSSBURI(uri: string | null): boolean`
 
 ### `isBendyButtV1MessageSSBURI(uri: string | null): boolean`
 
 ### `isGabbyGroveV1MessageSSBURI(uri: string | null): boolean`
 
-### `isBlobSSBURI(uri: string | null): boolean`
+### `isClassicBlobSSBURI(uri: string | null): boolean`
 
 ### `isAddressSSBURI(uri: string | null): boolean`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,18 @@
 import {BlobId, FeedId, MsgId} from 'ssb-typescript';
 
 type FeedTF =
+  | ['feed', 'classic']
   | ['feed', 'ed25519']
   | ['feed', 'bendybutt-v1']
   | ['feed', 'gabbygrove-v1']
   | ['feed', 'buttwoo-v1'];
 type MessageTF =
+  | ['message', 'classic']
   | ['message', 'sha256']
   | ['message', 'bendybutt-v1']
   | ['message', 'gabbygrove-v1']
   | ['message', 'buttwoo-v1'];
-type BlobTF = ['blob', 'sha256'];
+type BlobTF = ['blob', 'classic'] | ['blob', 'sha256'];
 type AddressTF = ['address', 'multiserver'];
 type EncryptionKeyTF = ['encryption-key', 'box2-dm-dh'];
 type IdentityTF = ['identity', 'po-box'] | ['identity', 'fusion'];
@@ -41,17 +43,17 @@ function extractBase64Data(pathname: string | null): string | null {
 
 export function fromFeedSigil(sigil: FeedId) {
   const data = Base64.unsafeToSafe(sigil.slice(1, -8));
-  return `ssb:feed/ed25519/${data}`;
+  return `ssb:feed/classic/${data}`;
 }
 
 export function fromMessageSigil(sigil: MsgId) {
   const data = Base64.unsafeToSafe(sigil.slice(1, -7));
-  return `ssb:message/sha256/${data}`;
+  return `ssb:message/classic/${data}`;
 }
 
 export function fromBlobSigil(sigil: BlobId) {
   const data = Base64.unsafeToSafe(sigil.slice(1, -7));
-  return `ssb:blob/sha256/${data}`;
+  return `ssb:blob/classic/${data}`;
 }
 
 export function fromMultiserverAddress(msaddr: string) {
@@ -60,20 +62,21 @@ export function fromMultiserverAddress(msaddr: string) {
 }
 
 export function toFeedSigil(uri: string): FeedId | null {
-  if (!isFeedSSBURI(uri)) return null;
+  if (!isClassicFeedSSBURI(uri)) return null;
   const base64Data = extractBase64Data(new URL(uri).pathname)!;
   if (!base64Data) return null;
   return `@${base64Data}.ed25519`;
 }
 
 export function toMessageSigil(uri: string): MsgId | null {
-  if (!isMessageSSBURI(uri)) return null;
+  if (!isClassicMessageSSBURI(uri)) return null;
   const base64Data = extractBase64Data(new URL(uri).pathname)!;
   if (!base64Data) return null;
   return `%${base64Data}.sha256`;
 }
 
 export function toBlobSigil(uri: string): BlobId | null {
+  if (!isClassicBlobSSBURI(uri)) return null;
   const base64Data = extractBase64Data(new URL(uri).pathname)!;
   if (!base64Data) return null;
   return `&${base64Data}.sha256`;
@@ -92,8 +95,11 @@ function checkTypeFormat(uri: string | null, ...args: TF): boolean {
     !!extractBase64Data(new URL(uri).pathname)) as any;
 }
 
-export function isFeedSSBURI(uri: string | null) {
-  return checkTypeFormat(uri, 'feed', 'ed25519');
+export function isClassicFeedSSBURI(uri: string | null) {
+  return (
+    checkTypeFormat(uri, 'feed', 'classic') ||
+    checkTypeFormat(uri, 'feed', 'ed25519')
+  );
 }
 
 export function isBendyButtV1FeedSSBURI(uri: string | null) {
@@ -108,8 +114,11 @@ export function isButtwooV1FeedSSBURI(uri: string | null) {
   return checkTypeFormat(uri, 'feed', 'buttwoo-v1');
 }
 
-export function isMessageSSBURI(uri: string | null) {
-  return checkTypeFormat(uri, 'message', 'sha256');
+export function isClassicMessageSSBURI(uri: string | null) {
+  return (
+    checkTypeFormat(uri, 'message', 'classic') ||
+    checkTypeFormat(uri, 'message', 'sha256')
+  );
 }
 
 export function isBendyButtV1MessageSSBURI(uri: string | null) {
@@ -124,8 +133,11 @@ export function isButtwooV1MessageSSBURI(uri: string | null) {
   return checkTypeFormat(uri, 'message', 'buttwoo-v1');
 }
 
-export function isBlobSSBURI(uri: string | null) {
-  return checkTypeFormat(uri, 'blob', 'sha256');
+export function isClassicBlobSSBURI(uri: string | null) {
+  return (
+    checkTypeFormat(uri, 'blob', 'classic') ||
+    checkTypeFormat(uri, 'blob', 'sha256')
+  );
 }
 
 export function isAddressSSBURI(uri: string | null) {
@@ -169,15 +181,15 @@ export function isExperimentalSSBURIWithAction(action: string) {
 
 export function isSSBURI(uri: string | null) {
   return (
-    isFeedSSBURI(uri) ||
+    isClassicFeedSSBURI(uri) ||
     isBendyButtV1FeedSSBURI(uri) ||
     isGabbyGroveV1FeedSSBURI(uri) ||
     isButtwooV1FeedSSBURI(uri) ||
-    isMessageSSBURI(uri) ||
+    isClassicMessageSSBURI(uri) ||
     isBendyButtV1MessageSSBURI(uri) ||
     isGabbyGroveV1MessageSSBURI(uri) ||
     isButtwooV1MessageSSBURI(uri) ||
-    isBlobSSBURI(uri) ||
+    isClassicBlobSSBURI(uri) ||
     isAddressSSBURI(uri) ||
     isEncryptionKeyBox2DMDiffieHellmanSSBURI(uri) ||
     isIdentityPOBoxSSBURI(uri) ||
@@ -189,6 +201,7 @@ export function isSSBURI(uri: string | null) {
 export function getFeedSSBURIRegex() {
   const type: FeedTF[0] = 'feed';
   const formatsWith3Parts: Array<FeedTF[1]> = [
+    'classic',
     'ed25519',
     'bendybutt-v1',
     'gabbygrove-v1',
@@ -212,6 +225,7 @@ export function getFeedSSBURIRegex() {
 export function getMessageSSBURIRegex() {
   const type: MessageTF[0] = 'message';
   const format: Array<MessageTF[1]> = [
+    'classic',
     'sha256',
     'bendybutt-v1',
     'gabbygrove-v1',
@@ -240,57 +254,77 @@ type CanonicalParts =
   | PartsFor<EncryptionKeyTF>
   | PartsFor<IdentityTF>;
 
-function validateParts(parts: Partial<CanonicalParts>) {
-  if (!parts.type) throw new Error('Missing required "type" property');
-  if (!parts.format) throw new Error('Missing required "format" property');
-  if (!parts.data) throw new Error('Missing required "data" property');
+function validateParts({type, format, data}: Partial<CanonicalParts>) {
+  if (!type) throw new Error('Missing required "type" property');
+  if (!format) throw new Error('Missing required "format" property');
+  if (!data) throw new Error('Missing required "data" property');
 
-  if (parts.type === 'feed') {
+  if (type === 'feed') {
     if (
-      parts.format !== 'ed25519' &&
-      parts.format !== 'bendybutt-v1' &&
-      parts.format !== 'gabbygrove-v1' &&
-      parts.format !== 'buttwoo-v1'
+      format !== 'classic' &&
+      format !== 'ed25519' &&
+      format !== 'bendybutt-v1' &&
+      format !== 'gabbygrove-v1' &&
+      format !== 'buttwoo-v1'
     ) {
-      throw new Error('Unknown format for type "feed": ' + parts.format);
+      throw new Error('Unknown format for type "feed": ' + format);
     } else return;
   }
 
-  if (parts.type === 'message') {
+  if (type === 'message') {
     if (
-      parts.format !== 'sha256' &&
-      parts.format !== 'bendybutt-v1' &&
-      parts.format !== 'gabbygrove-v1' &&
-      parts.format !== 'buttwoo-v1'
+      format !== 'classic' &&
+      format !== 'sha256' &&
+      format !== 'bendybutt-v1' &&
+      format !== 'gabbygrove-v1' &&
+      format !== 'buttwoo-v1'
     ) {
-      throw new Error('Unknown format for type "message": ' + parts.format);
+      throw new Error('Unknown format for type "message": ' + format);
     } else return;
   }
 
-  if (parts.type === 'blob') {
-    if (parts.format !== 'sha256') {
-      throw new Error('Unknown format for type "blob": ' + parts.format);
+  if (type === 'blob') {
+    if (format !== 'classic' && format !== 'sha256') {
+      throw new Error('Unknown format for type "blob": ' + format);
     } else return;
   }
 
-  if (parts.type === 'address') {
-    if (parts.format !== 'multiserver') {
-      throw new Error('Unknown format for type "address": ' + parts.format);
+  if (type === 'address') {
+    if (format !== 'multiserver') {
+      throw new Error('Unknown format for type "address": ' + format);
     } else return;
   }
 
-  if (parts.type === 'encryption-key') {
-    if (parts.format !== 'box2-dm-dh') {
-      throw new Error(
-        'Unknown format for type "encryption-key": ' + parts.format,
-      );
+  if (type === 'encryption-key') {
+    if (format !== 'box2-dm-dh') {
+      throw new Error('Unknown format for type "encryption-key": ' + format);
     } else return;
   }
 
-  if (parts.type === 'identity') {
-    if (parts.format !== 'po-box' && parts.format !== 'fusion') {
-      throw new Error('Unknown format for type "identity": ' + parts.format);
+  if (type === 'identity') {
+    if (format !== 'po-box' && format !== 'fusion') {
+      throw new Error('Unknown format for type "identity": ' + format);
     } else return;
+  }
+}
+
+/**
+ * *Mutates* the `parts` object to avoid deprecated URIs.
+ * @param parts
+ */
+function fixParts(parts: Partial<CanonicalParts>) {
+  const {type, format} = parts;
+  if (type === 'feed' && format === 'ed25519') {
+    parts.format = 'classic';
+    return;
+  }
+  if (type === 'message' && format === 'sha256') {
+    parts.format = 'classic';
+    return;
+  }
+  if (type === 'blob' && format === 'sha256') {
+    parts.format = 'classic';
+    return;
   }
 }
 
@@ -315,6 +349,7 @@ export function decompose(uri: string): CanonicalParts {
   const data = Base64.safeToUnsafe(safeData);
   const parts = {type, format, data} as CanonicalParts;
   validateParts(parts);
+  fixParts(parts);
   if (safeExtraData) parts.extraData = Base64.safeToUnsafe(safeExtraData);
   return parts;
 }

--- a/test/compose.js
+++ b/test/compose.js
@@ -7,7 +7,7 @@ test('compose() a message URI', (t) => {
   t.plan(1);
   const uri = ssbUri.compose({
     type: 'message',
-    format: 'sha256',
+    format: 'classic',
     data: 'g3hPVPDEO1Aj/uPl0+J2NlhFB2bbFLIHlty+YuqFZ3w=',
   });
   t.equals(uri, fixtures.message.uri);
@@ -18,7 +18,7 @@ test('decompose() a message URI', (t) => {
   const parts = ssbUri.decompose(fixtures.message.uri);
   t.deepEquals(Object.keys(parts), ['type', 'format', 'data'], 'obj keys');
   t.equals(parts.type, 'message', 'type');
-  t.equals(parts.format, 'sha256', 'format');
+  t.equals(parts.format, 'classic', 'format');
   t.equals(parts.data, 'g3hPVPDEO1Aj/uPl0+J2NlhFB2bbFLIHlty+YuqFZ3w=', 'data');
 });
 
@@ -32,7 +32,7 @@ test('compose() a feed URI', (t) => {
   t.plan(1);
   const uri = ssbUri.compose({
     type: 'feed',
-    format: 'ed25519',
+    format: 'classic',
     data: '+oaWWDs8g73EZFUMfW37R/ULtFEjwKN_DczvdYihjbU=',
   });
   t.equals(uri, fixtures.feed.uri);
@@ -50,4 +50,49 @@ test('compose() a feed URI with extra data', (t) => {
   t.equals(uri, fixtures.feed.uri7);
   const parts2 = ssbUri.decompose(uri);
   t.deepEqual(parts2, parts);
+});
+
+test('compose() a deprecated format create deprecated URI', (t) => {
+  t.plan(3);
+  const msgUri = ssbUri.compose({
+    type: 'message',
+    format: 'sha256',
+    data: 'g3hPVPDEO1Aj/uPl0+J2NlhFB2bbFLIHlty+YuqFZ3w=',
+  });
+  t.equals(msgUri, fixtures.message.uri7);
+
+  const feedUri = ssbUri.compose({
+    type: 'feed',
+    format: 'ed25519',
+    data: '+oaWWDs8g73EZFUMfW37R/ULtFEjwKN_DczvdYihjbU=',
+  });
+  t.equals(feedUri, fixtures.feed.uri8);
+
+  const blobUri = ssbUri.compose({
+    type: 'blob',
+    format: 'sha256',
+    data: 'sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n/OJGSC1U=',
+  });
+  t.equals(blobUri, fixtures.blob.uri4);
+});
+
+test('decompose() a deprecated URI gives modern parts', (t) => {
+  t.plan(4 * 3);
+  const p1 = ssbUri.decompose(fixtures.message.uri7);
+  t.deepEquals(Object.keys(p1), ['type', 'format', 'data'], 'obj keys');
+  t.equals(p1.type, 'message', 'type');
+  t.equals(p1.format, 'classic', 'format');
+  t.equals(p1.data, 'g3hPVPDEO1Aj/uPl0+J2NlhFB2bbFLIHlty+YuqFZ3w=', 'data');
+
+  const p2 = ssbUri.decompose(fixtures.feed.uri8);
+  t.deepEquals(Object.keys(p2), ['type', 'format', 'data'], 'obj keys');
+  t.equals(p2.type, 'feed', 'type');
+  t.equals(p2.format, 'classic', 'format');
+  t.equals(p2.data, '+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=', 'data');
+
+  const p3 = ssbUri.decompose(fixtures.blob.uri4);
+  t.deepEquals(Object.keys(p3), ['type', 'format', 'data'], 'obj keys');
+  t.equals(p3.type, 'blob', 'type');
+  t.equals(p3.format, 'classic', 'format');
+  t.equals(p3.data, 'sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n/OJGSC1U=', 'data');
 });

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -3,30 +3,33 @@ module.exports = {};
 
 module.exports.message = {
   sigil: '%g3hPVPDEO1Aj/uPl0+J2NlhFB2bbFLIHlty+YuqFZ3w=.sha256',
-  uri: 'ssb:message/sha256/g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=',
+  uri: 'ssb:message/classic/g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=',
   uri2: 'ssb:message:sha256:g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=',
   uri3: 'ssb://message/sha256/g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=',
   uri4: 'ssb://message/bendybutt-v1/Z0rMVMDEO1Aj0uPl0_J2NlhFB2bbFLIHlty_YuqArFq=',
   uri5: 'ssb:message/gabbygrove-v1/QibgMEFVrupoOpiILKVoNXnhzdVQVZf7dkmL9MSXO5g=',
   uri6: 'ssb://message/buttwoo-v1/Z0rMVMDEO1Aj0uPl0_J2NlhFB2bbFLIHlty_YuqArFq=',
+  uri7: 'ssb:message/sha256/g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=',
 };
 
 module.exports.feed = {
   sigil: '@+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=.ed25519',
-  uri: 'ssb:feed/ed25519/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
+  uri: 'ssb:feed/classic/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
   uri2: 'ssb:feed:ed25519:-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
   uri3: 'ssb://feed/ed25519/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
   uri4: 'ssb:feed/bendybutt-v1/APaWWDs8g73EZFUMfW37RBULtFEjwKNbDczvdYiRXtA=',
   uri5: 'ssb:feed/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=',
   uri6: 'ssb:feed/buttwoo-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=',
   uri7: 'ssb:feed/buttwoo-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=/Z0rMVMDEO1Aj0uPl0_J2NlhFB2bbFLIHlty_YuqArFq=',
+  uri8: 'ssb:feed/ed25519/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
 };
 
 module.exports.blob = {
   sigil: '&sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n/OJGSC1U=.sha256',
-  uri: 'ssb:blob/sha256/sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n_OJGSC1U=',
+  uri: 'ssb:blob/classic/sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n_OJGSC1U=',
   uri2: 'ssb:blob:sha256:sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n_OJGSC1U=',
   uri3: 'ssb://blob/sha256/sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n_OJGSC1U=',
+  uri4: 'ssb:blob/sha256/sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n_OJGSC1U=',
 };
 
 module.exports.address = {

--- a/test/happy.js
+++ b/test/happy.js
@@ -8,9 +8,9 @@ const ssbUri = require('../lib');
 test('message URIs recognized', (t) => {
   t.plan(7);
   t.true(ssbUri.isSSBURI(fixtures.message.uri));
-  t.true(ssbUri.isMessageSSBURI(fixtures.message.uri));
-  t.true(ssbUri.isMessageSSBURI(fixtures.message.uri2));
-  t.true(ssbUri.isMessageSSBURI(fixtures.message.uri3));
+  t.true(ssbUri.isClassicMessageSSBURI(fixtures.message.uri));
+  t.true(ssbUri.isClassicMessageSSBURI(fixtures.message.uri2));
+  t.true(ssbUri.isClassicMessageSSBURI(fixtures.message.uri3));
 
   t.true(ssbUri.isBendyButtV1MessageSSBURI(fixtures.message.uri4));
   t.true(ssbUri.isGabbyGroveV1MessageSSBURI(fixtures.message.uri5));
@@ -42,9 +42,9 @@ test('message from URI to sigil', (t) => {
 test('feed URIs recognized', (t) => {
   t.plan(8);
   t.true(ssbUri.isSSBURI(fixtures.feed.uri));
-  t.true(ssbUri.isFeedSSBURI(fixtures.feed.uri));
-  t.true(ssbUri.isFeedSSBURI(fixtures.feed.uri2));
-  t.true(ssbUri.isFeedSSBURI(fixtures.feed.uri3));
+  t.true(ssbUri.isClassicFeedSSBURI(fixtures.feed.uri));
+  t.true(ssbUri.isClassicFeedSSBURI(fixtures.feed.uri2));
+  t.true(ssbUri.isClassicFeedSSBURI(fixtures.feed.uri3));
 
   t.true(ssbUri.isBendyButtV1FeedSSBURI(fixtures.feed.uri4));
   t.true(ssbUri.isGabbyGroveV1FeedSSBURI(fixtures.feed.uri5));
@@ -106,9 +106,9 @@ test('feed from URI to sigil', (t) => {
 test('blob URIs recognized', (t) => {
   t.plan(4);
   t.true(ssbUri.isSSBURI(fixtures.blob.uri));
-  t.true(ssbUri.isBlobSSBURI(fixtures.blob.uri));
-  t.true(ssbUri.isBlobSSBURI(fixtures.blob.uri2));
-  t.true(ssbUri.isBlobSSBURI(fixtures.blob.uri3));
+  t.true(ssbUri.isClassicBlobSSBURI(fixtures.blob.uri));
+  t.true(ssbUri.isClassicBlobSSBURI(fixtures.blob.uri2));
+  t.true(ssbUri.isClassicBlobSSBURI(fixtures.blob.uri3));
 });
 
 test('blob from sigil to URI', (t) => {

--- a/test/sad.js
+++ b/test/sad.js
@@ -5,7 +5,7 @@ const ssbUri = require('../lib');
 
 test('message URI not recognized as feed URI', (t) => {
   t.plan(1);
-  t.false(ssbUri.isFeedSSBURI(fixtures.message.uri));
+  t.false(ssbUri.isClassicFeedSSBURI(fixtures.message.uri));
 });
 
 test('bendybutt message URI cannot be converted to sigil', (t) => {
@@ -20,17 +20,17 @@ test('gabbygrove message URI cannot be converted to sigil', (t) => {
 
 test('falsy input not recognized as feed', (t) => {
   t.plan(1);
-  t.false(ssbUri.isFeedSSBURI(null));
+  t.false(ssbUri.isClassicFeedSSBURI(null));
 });
 
 test('falsy input not recognized as message', (t) => {
   t.plan(1);
-  t.false(ssbUri.isMessageSSBURI(null));
+  t.false(ssbUri.isClassicMessageSSBURI(null));
 });
 
 test('falsy input not recognized as blob', (t) => {
   t.plan(1);
-  t.false(ssbUri.isBlobSSBURI(null));
+  t.false(ssbUri.isClassicBlobSSBURI(null));
 });
 
 test('falsy input not recognized as address', (t) => {
@@ -45,7 +45,7 @@ test('falsy input not recognized as experimental', (t) => {
 
 test('invalid SSB URI input not recognized', (t) => {
   t.plan(1);
-  t.false(ssbUri.isFeedSSBURI('ssb:feed/ed25519/'));
+  t.false(ssbUri.isClassicFeedSSBURI('ssb:feed/ed25519/'));
 });
 
 test('invalid feed SSB URI cannot be converted to sigil', (t) => {


### PR DESCRIPTION
Support ssb-uri-spec version 1.1, which means that we added support for `ssb:feed/classic` as first-class URIs, while `ssb:feed/ed25519` is still supported, but is deprecated. (Similarly for `ssb:message/classic` and `ssb:message/ed25519`, `ssb:blob/classic` and `ssb:blob/ed25519`.)

`compose({type: 'feed', format: 'ed25519', data})` is still going to return the deprecated URI `ssb:feed/ed25519/${data}`, but `decompose(uri)` will return `{type: 'feed', format: 'classic', data}`.

**Breaking change:**

- `isFeedSSBURI` renamed to `isClassicFeedSSBURI`
- `isMessageSSBURI` renamed to `isClassicMessageSSBURI`
- `isBlobSSBURI` renamed to `isClassicBlobSSBURI`

Pending on https://github.com/ssbc/ssb-uri-spec/pull/13 reviewed and merged first.