### PR TITLE
Faster decompose

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -341,10 +341,11 @@ export function compose(parts: Partial<CanonicalParts>) {
 }
 
 export function decompose(uri: string): CanonicalParts {
-  const pathname = new URL(uri).pathname;
-  if (!pathname) {
+  if (uri.length < 5) {
     throw new Error('Invalid SSB URI: ' + uri);
   }
+
+  const pathname = uri.substring(4);
   const [type, format, safeData, safeExtraData] = pathname.split('/');
   const data = Base64.safeToUnsafe(safeData);
   const parts = {type, format, data} as CanonicalParts;


### PR DESCRIPTION
Context:

I started looking at buttwoo again to see where the bottleneck is and found that BFE encode / decode are really quite slow. Using the benchmark in db2 and ebt I tracked the problem down to slow decoding in BFE and then slow encoding in uri2 because of new URI instead of just doing substring. This takes care of the latter and makes encoding roughly 2x faster.